### PR TITLE
ReminderCommand and ReminderCommandParser to Allow Custom Number of Days

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ReminderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ReminderCommand.java
@@ -3,35 +3,42 @@ package seedu.address.logic.commands;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
+
 /**
- * Filters list to upcoming interviews in the next 3 days
+ * Filters list to upcoming interviews in the next 'n' days
  */
 public class ReminderCommand extends Command {
     public static final String COMMAND_WORD = "reminder";
-    public static final String MESSAGE_USAGE = "Reminder should not have any arguments.";
-    public static final String MESSAGE_SUCCESS = "Listed applications that are due or have interviews in 3 days.";
+    public static final String MESSAGE_USAGE = "Reminder should be followed by the number of days.\n"
+            + "Example: reminder 4";
+    public static final String MESSAGE_SUCCESS = "Listed applications that are due or have interviews in %1$d days.";
+
+    private int numberOfDays;
+
+    public ReminderCommand(int numberOfDays) {
+        this.numberOfDays = numberOfDays;
+    }
 
     @Override
     public CommandResult execute(Model model) {
-        // Define a predicate to filter persons with interviews within 3 days
-        Predicate<Person> isWithin3DaysPredicate = person ->
-                person.getInterviewDate() != null && person.getInterviewDate().isWithin3Days();
+        // Define a predicate to filter persons with interviews within N days
+        Predicate<Person> isWithinNDaysPredicate = person ->
+                person.getInterviewDate() != null && person.getInterviewDate().isWithinNDays(numberOfDays);
 
         // Get all persons from the model
         List<Person> allPersons = model.getAddressBook().getPersonList();
 
         // Filter the persons using the predicate
         List<Person> reminderList = allPersons.stream()
-                .filter(isWithin3DaysPredicate)
+                .filter(isWithinNDaysPredicate)
                 .collect(Collectors.toList());
 
         // Update the filtered list in the model using a predicate
-        model.updateFilteredPersonList(isWithin3DaysPredicate);
+        model.updateFilteredPersonList(isWithinNDaysPredicate);
 
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, numberOfDays));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -80,7 +80,7 @@ public class AddressBookParser {
         case NoteCommand.COMMAND_WORD:
             return new NoteCommandParser().parse(arguments);
         case ReminderCommand.COMMAND_WORD:
-            return new ReminderCommand();
+            return new ReminderCommandParser().parse(arguments);
         default:
             logger.finer("This user input caused a ParseException: " + userInput);
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/ReminderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ReminderCommandParser.java
@@ -1,30 +1,32 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import seedu.address.logic.commands.ReminderCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+
 /**
- * Parses input arguments and creates a new ReminderCommand object
+ * Parses the given {@code String} of arguments in the context of the ReminderCommand
+ * and returns a ReminderCommand object for execution.
+ * @throws ParseException if the user input does not conform the expected format
  */
+
 public class ReminderCommandParser implements Parser<ReminderCommand> {
+    public static final String INVALID_NUMBER_OF_DAYS = "Number of days must be a positive integer.";
 
     /**
      * Parses the given {@code String} of arguments in the context of the ReminderCommand
      * and returns a ReminderCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
-    @Override
     public ReminderCommand parse(String args) throws ParseException {
-        // Trim the input arguments to remove leading and trailing whitespaces
-        String trimmedArgs = args.trim();
-
-        // Check if the trimmedArgs is empty
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ReminderCommand.MESSAGE_USAGE));
+        try {
+            int numberOfDays = Integer.parseInt(args.trim());
+            if (numberOfDays <= 0) {
+                throw new ParseException(INVALID_NUMBER_OF_DAYS);
+            }
+            return new ReminderCommand(numberOfDays);
+        } catch (NumberFormatException e) {
+            throw new ParseException(INVALID_NUMBER_OF_DAYS);
         }
-
-        // Return a new instance of ReminderCommand
-        return new ReminderCommand();
     }
 }

--- a/src/main/java/seedu/address/model/person/InterviewDate.java
+++ b/src/main/java/seedu/address/model/person/InterviewDate.java
@@ -78,10 +78,12 @@ public class InterviewDate {
     public int hashCode() {
         return value.hashCode();
     }
+
     /**
-     * Checks if this InterviewDate is in the next 3 days.
+     * Checks if this InterviewDate is in the next N days.
      */
-    public boolean isWithin3Days() {
+
+    public boolean isWithinNDays(int numberOfDays) {
         if (value == null) {
             return false;
         }
@@ -91,7 +93,7 @@ public class InterviewDate {
         // Calculate the difference in days between the interview date and the current date
         long daysDifference = ChronoUnit.DAYS.between(currentDate, value);
         // Check if the difference is less than or equal to 3
-        return daysDifference > 0 && daysDifference <= 3;
+        return daysDifference > 0 && daysDifference <= numberOfDays;
     }
 
     //    public int compareTo(InterviewDate otherInterviewDate) {


### PR DESCRIPTION
In this commit, I updated the ReminderCommand and ReminderCommandParser to allow specifying any number of days for filtering upcoming interviews instead of a fixed 3-day period.

Modified the ReminderCommand class to accept a variable number of days through its constructor. Updated the ReminderCommandParser to parse the user input and pass the specified number of days to the ReminderCommand constructor. Refactored the execution logic in ReminderCommand to utilize the provided number of days for filtering upcoming interviews. This change enhances the flexibility of the ReminderCommand feature, allowing users to specify any desired number of days for viewing upcoming interviews.

BUT I FORGOT TO SWITCH BRANCH HAHAHA