### PR TITLE
Bug fix for filter command failing with inputs

### DIFF
--- a/src/main/java/seedu/internhub/model/person/Tag.java
+++ b/src/main/java/seedu/internhub/model/person/Tag.java
@@ -103,7 +103,7 @@ public class Tag {
     }
 
     public String getTagShort() {
-        return this.tagInput;
+        return this.tagInput.toUpperCase();
     }
 
     @Override


### PR DESCRIPTION
PR aims to fix the bug identified by PE-D : 
Filter command fails when user enters valid inputs in lowercase (#147)

- Expected behaviour : Filter should work regardless of case and fetch the relevant internship contacts

- Actual behaviour : Filter command does not function when there are contacts with lowercase tags & there is no workaround available as with current implementation of filter - unable to successfully locate the tags with lowercase

- Remedy / Bug Fix : ensure that Tags.getTagShort() returns as UpperCase to avoid such inaccuracies.